### PR TITLE
Fix global vars causing duplicate symbols with gcc10

### DIFF
--- a/ni/src/ncl/NclApi.c
+++ b/ni/src/ncl/NclApi.c
@@ -140,9 +140,10 @@ extern char *the_input_buffer;
 extern char *the_input_buffer_ptr;
 extern int the_input_buffer_size;
 
-FILE *thefptr;
-FILE *theoptr;
-int cmd_line;
+extern FILE *thefptr;
+extern FILE *theoptr;
+extern int cmd_line;
+	
 extern int cur_line_number;
 extern char *cur_line_text;
 extern int cur_line_maxsize;

--- a/ni/src/ncl/NclHDF5.c
+++ b/ni/src/ncl/NclHDF5.c
@@ -240,7 +240,7 @@ struct _HDF5FileRecord
 
 #define NUMPOSDIMNAMES	6
 
-NclQuark possibleDimNames[NUMPOSDIMNAMES];
+static NclQuark possibleDimNames[NUMPOSDIMNAMES];
 
 static int _H5_initializeOptions 
 #if    NhlNeedProto

--- a/ni/src/ncl/NclNewHDF5.c
+++ b/ni/src/ncl/NclNewHDF5.c
@@ -82,7 +82,7 @@ static NrmQuark Qfill_val;
 
 #define NUMPOSDIMNAMES	6
 
-NclQuark possibleDimNames[NUMPOSDIMNAMES];
+static NclQuark possibleDimNames[NUMPOSDIMNAMES];
 
 #ifndef FALSE
 #define FALSE           0


### PR DESCRIPTION
NclApi.c: Change 3 global vars to extern.
Fix for duplicate symbol errors with gcc10.
These 3 are defined as globals in NclGlobalVars.h.
This is better than -fcommon.